### PR TITLE
Add pry-rails to development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem 'web-console', '~> 3.0'
   gem 'spring'
   gem 'brakeman', require: false
+  gem 'pry-rails'
 end
 
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       timers (>= 4.1.1)
     celluloid-supervision (0.20.5)
       timers (>= 4.1.1)
+    coderay (1.1.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -134,6 +135,12 @@ GEM
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     pg (0.18.4)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     puma (2.15.3)
     rack (2.0.0.alpha)
       json
@@ -181,6 +188,7 @@ GEM
     slim (3.0.6)
       temple (~> 0.7.3)
       tilt (>= 1.3.3, < 2.1)
+    slop (3.6.0)
     spring (1.6.1)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
@@ -226,6 +234,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   pg
+  pry-rails
   puma
   rails (>= 5.0.0.beta1, < 5.1)
   rails-assets-bootstrap!


### PR DESCRIPTION
@teknofire @grimm 
I think we should be using [pry](https://github.com/pry/pry) more.    This change makes pry the default shell for the rails console for this project.
