### PR TITLE
disable the css and js generation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,7 @@ module Awrvi
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.generators.stylesheets = false
+    config.generators.javascripts = false
   end
 end


### PR DESCRIPTION
This will prevent the empty css and javascript (coffeescript) files from being generated automatically.

If you want to generate an asset file use
- `rails g assets [NAME] -j` for javascript
- `rails g assets [NAME] -y` for css

@gina-alaska/awrvi ready for review
