### PR TITLE
Set null: false on indices/awrvi_version_id

### DIFF
--- a/app/models/index.rb
+++ b/app/models/index.rb
@@ -1,6 +1,6 @@
 class Index < ApplicationRecord
   belongs_to :community
-  belongs_to :category
+  belongs_to :awrvi_version, class_name: Category
   has_many :index_choices, dependent: :destroy
   has_many :choices, through: :index_choices
 end

--- a/db/migrate/20160128235605_disable_null_on_index_awrvi_version_relation.rb
+++ b/db/migrate/20160128235605_disable_null_on_index_awrvi_version_relation.rb
@@ -1,0 +1,5 @@
+class DisableNullOnIndexAwrviVersionRelation < ActiveRecord::Migration[5.0]
+  def change
+    change_column :indices, :awrvi_version_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160127193036) do
+ActiveRecord::Schema.define(version: 20160128235605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20160127193036) do
 
   create_table "indices", force: :cascade do |t|
     t.datetime "finalized_at"
-    t.integer  "awrvi_version_id"
+    t.integer  "awrvi_version_id",                         null: false
     t.integer  "community_id"
     t.decimal  "awrvi_index",      precision: 6, scale: 5
     t.datetime "rejected_at"

--- a/test/controllers/indices_controller_test.rb
+++ b/test/controllers/indices_controller_test.rb
@@ -22,7 +22,8 @@ class IndicesControllerTest < ActionDispatch::IntegrationTest
           awrvi_index: @index.awrvi_index,
           finalized_at: @index.finalized_at,
           rejected_at: @index.rejected_at,
-          rejected_reason: @index.rejected_reason
+          rejected_reason: @index.rejected_reason,
+          awrvi_version_id: @index.awrvi_version.id
         }
       }
     end

--- a/test/fixtures/indices.yml
+++ b/test/fixtures/indices.yml
@@ -5,11 +5,11 @@ one:
   awrvi_index: 9.99
   rejected_at: 2016-01-13 16:11:26
   rejected_reason: MyText
-  awrvi_version_id: 
+  awrvi_version: one
 
 two:
   finalized_at: 2016-01-13 16:11:26
   awrvi_index: 9.99
   rejected_at: 2016-01-13 16:11:26
   rejected_reason: MyText
-  awrvi_version_id:
+  awrvi_version: one


### PR DESCRIPTION
You can't have an index without it pointing at an AWRVI version. This adds
some safety to ensure we're always linking the two together.
