### PR TITLE
updating to turbolinks 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # gem 'therubyracer', platforms: :ruby
 
 gem 'jquery-rails'
-gem 'turbolinks'
+gem 'turbolinks', '~> 5.0.0.beta'
 gem 'jbuilder', '~> 2.0'
 gem 'puma'
 gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,8 +230,9 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
-    turbolinks (2.5.3)
-      coffee-rails
+    turbolinks (5.0.0.beta2)
+      turbolinks-source
+    turbolinks-source (5.0.0.beta3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -283,7 +284,7 @@ DEPENDENCIES
   rubocop
   simple_form
   spring
-  turbolinks
+  turbolinks (~> 5.0.0.beta)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 3.0)


### PR DESCRIPTION
Pretty straight forward at this point since we have no javascript that depends on page loading.  

Be sure to checkout https://github.com/turbolinks/turbolinks for the changes to the way it works.
