### PR TITLE
Cleanup dev tasks

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -3,7 +3,9 @@ namespace :dev do
   task prime: :environment do
     next if Index.any?
     awrvi_version = Category.roots.first
-    user = User.first_or_create(name: 'system', email: 'system@system.com', encrypted_password: 'system', password: 'system88', sign_in_count: 1, user_admin: false, category_admin: false)
+    user = User.first_or_create(name: 'system', email: 'system@system.com',
+                                encrypted_password: 'system', password: 'system88',
+                                sign_in_count: 1)
 
     puts "Generating index data for communities"
     Community.find_each do |community|
@@ -55,11 +57,12 @@ namespace :dev do
 
       user = User.where(email: ENV['AWRVI_USER']).first || User.last
       user.update_attribute(attribute, !user.send(attribute))
-      puts "User #{user.name} #{attribute.to_s} is now set to #{user.send(attribute)}"
+      puts "User #{user.name} #{attribute} is now set to #{user.send(attribute)}"
     end
   end
 
   private
+
   def generate_index(community, user, awrvi_version)
     index = community.indices.build(awrvi_version: awrvi_version, user: user)
     make_choices(index, awrvi_version.leaves)
@@ -76,7 +79,6 @@ namespace :dev do
       index.index_category_choices.build(category: leaf, choice: choice)
     end
   end
-
 
   def install_phantomjs
     version = 'phantomjs-2.1.1-linux-x86_64'

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -31,31 +31,32 @@ namespace :dev do
     install_phantomjs
   end
 
-  desc 'Toggle user permission for category admin'
-  task category_admin: :environment do
-    return unless Rails.env.development?
+  desc 'Toggle all admin flags for user'
+  task admin: ['admin:category', 'admin:index', 'admin:user']
 
-    user = User.where(email: ENV['AWRVI_USER']).first || User.last
-    user.update_attribute(:category_admin, !user.category_admin)
-    puts "User #{user.name} category_admin is now set to #{user.category_admin}"
-  end
+  namespace :admin do
+    desc 'Toggle users category_admin flag'
+    task category: :environment do
+      toggle_flag(:category_admin)
+    end
 
-  desc 'Toggle users user_admin flag'
-  task user_admin: :environment do
-    return unless Rails.env.development?
+    desc 'Toggle users user_admin flag'
+    task user: :environment do
+      toggle_flag(:user_admin)
+    end
 
-    user = User.where(email: ENV['AWRVI_USER']).first || User.last
-    user.update_attribute(:user_admin, !user.user_admin)
-    puts "Set #{user.email} user_admin to #{user.user_admin}."
-  end
+    desc 'Toggle users user_admin flag'
+    task index: :environment do
+      toggle_flag(:index_admin)
+    end
 
-  desc 'Toggle users user_admin flag'
-  task index_admin: :environment do
-    return unless Rails.env.development?
+    def toggle_flag(attribute)
+      return unless Rails.env.development?
 
-    user = User.where(email: ENV['AWRVI_USER']).first || User.last
-    user.update_attribute(:index_admin, !user.index_admin)
-    puts "Set #{user.email} index_admin to #{user.index_admin}."
+      user = User.where(email: ENV['AWRVI_USER']).first || User.last
+      user.update_attribute(attribute, !user.send(attribute))
+      puts "User #{user.name} #{attribute.to_s} is now set to #{user.send(attribute)}"
+    end
   end
 
   private

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -2,6 +2,7 @@ namespace :dev do
   desc 'Create index test data.'
   task prime: :environment do
     next if Index.any?
+    Rake::Task["db:seed"].invoke
     awrvi_version = Category.roots.first
     user = User.first_or_create(name: 'system', email: 'system@system.com',
                                 encrypted_password: 'system', password: 'system88',

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,4 +1,7 @@
 namespace :dev do
+  desc 'Reset the database after changing branches'
+  task reset: ['db:migrate:reset', 'dev:prime']
+
   desc 'Create index test data.'
   task prime: :environment do
     next if Index.any?


### PR DESCRIPTION
closes #99 

This adds a dev:admin rake task to toggle all flags,  and moves the individual toggles to dev:admin:ATTRIBUTE.

It also cleans up the prime task:
- Reuse existing user if present. 
- Allow ~40% of communities to generate indices
- Allow communities to generate 1-3 indices
- Add reset and clean tasks to prime
