### PR TITLE
Remove awrvi_index column from indicies

### DIFF
--- a/app/views/indices/index.html.haml
+++ b/app/views/indices/index.html.haml
@@ -4,13 +4,11 @@
   %thead
     %tr
       %th Published date
-      %th Awrvi index
       %th{:colspan => "3"}
   %tbody
     - @indices.each do |index|
       %tr
         %td= index.published_at
-        %td= index.awrvi_index
         %td= link_to 'Show', index
         %td= link_to 'Edit', edit_index_path(index)
         %td= link_to 'Destroy', index, method: :delete, data: { confirm: 'Are you sure?' }

--- a/db/migrate/20160401215102_remove_awrvi_index_from_indices.rb
+++ b/db/migrate/20160401215102_remove_awrvi_index_from_indices.rb
@@ -1,0 +1,5 @@
+class RemoveAwrviIndexFromIndices < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :indices, :awrvi_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329204552) do
+ActiveRecord::Schema.define(version: 20160401215102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,15 +83,14 @@ ActiveRecord::Schema.define(version: 20160329204552) do
 
   create_table "indices", force: :cascade do |t|
     t.datetime "published_at"
-    t.integer  "awrvi_version_id",                                         null: false
-    t.integer  "community_id",                                             null: false
-    t.decimal  "awrvi_index",      precision: 6, scale: 5
+    t.integer  "awrvi_version_id",                 null: false
+    t.integer  "community_id",                     null: false
     t.datetime "hidden_at"
     t.text     "hidden_reason"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "hidden",                                   default: false, null: false
+    t.boolean  "hidden",           default: false, null: false
   end
 
   add_index "indices", ["awrvi_version_id"], name: "index_indices_on_awrvi_version_id", using: :btree

--- a/test/controllers/indices_controller_test.rb
+++ b/test/controllers/indices_controller_test.rb
@@ -22,7 +22,6 @@ class IndicesControllerTest < ActionDispatch::IntegrationTest
     assert_difference('Index.count') do
       post community_indices_url(communities(:one)), params: {
         index: {
-          awrvi_index: @index.awrvi_index,
           awrvi_version_id: @index.awrvi_version.id,
           index_category_choices_attributes: {
             "0": {
@@ -52,7 +51,6 @@ class IndicesControllerTest < ActionDispatch::IntegrationTest
     login_as(users(:two))
     patch index_url(@index), params: {
       index: {
-        awrvi_index: @index.awrvi_index,
         index_category_choices_attributes: {
           "0": {
             category: categories(:leaf_1),

--- a/test/fixtures/indices.yml
+++ b/test/fixtures/indices.yml
@@ -1,14 +1,12 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 unpublished:
-  awrvi_index: 9.99
   awrvi_version: root
   user: one
   community: one
 
 published:
   published_at: 2016-01-13 16:11:26
-  awrvi_index: 9.99
   awrvi_version: root
   user: two
   community: two


### PR DESCRIPTION
Fixes #141 

This removes the awrvi_index column from the indices model.  All (current) uses of the vulnerability index are generated dynamically. This field is never set and its presence is causing confusion.
