### PR TITLE
Rename AWRVI Dashboard to Vulnerability Assessment

### DIFF
--- a/app/helpers/communities_helper.rb
+++ b/app/helpers/communities_helper.rb
@@ -3,11 +3,11 @@ module CommunitiesHelper
     truthy ? 'with-sidebar' : 'without-sidebar'
   end
 
-  def latest_awrvi_dashboard(community)
-    published_dashboards(community).recent.first
+  def latest_vulnerability_assesment(community)
+    published_assessments(community).recent.first
   end
 
-  def published_dashboards(community, opts = {})
+  def published_assessments(community, opts = {})
     indices = community.indices.published
     indices = indices.where.not(id: opts[:exclude]) if opts.include?(:exclude)
 

--- a/app/views/communities/_community.html.haml
+++ b/app/views/communities/_community.html.haml
@@ -1,4 +1,4 @@
-- current_index = @index || latest_awrvi_dashboard(@community)
+- current_index = @index || latest_vulnerability_assesment(@community)
 .pull-right{ style: 'margin-top: 25px;' }
   .btn-toolbar
     .btn-group
@@ -11,7 +11,7 @@
       - if can? :hide, current_index
         = link_to "Hide", edit_manage_index_path(current_index),  class: 'btn btn-default'
 
-%h1 AWRVI Dashboard
+%h1 Vulnerability Assessment
 - if !current_index
   = render 'communities/no_published_available', community: @community
 - else
@@ -45,7 +45,7 @@
     Back to search
 
   = link_to new_community_index_path(@community), class: 'btn btn-success btn-block' do
-    Start new AWRVI Dashboard
+    Start new Vulnerabilty Assesment
 
   - if can? :edit, @community
     = link_to edit_community_path(@community), class: 'btn btn-default btn-block' do
@@ -53,4 +53,4 @@
       Edit community
 
   - if can? :create, Index
-    = render 'communities/past_awrvi_dashboards', community: @community
+    = render 'communities/past_vulnerability_assessments', community: @community

--- a/app/views/communities/_mini_community.html.haml
+++ b/app/views/communities/_mini_community.html.haml
@@ -1,8 +1,8 @@
 %h1.community-title= community.name
 
 .community-index
-  - if @index || latest_awrvi_dashboard(community)
-    = render 'indices/mini_index', index: @index || latest_awrvi_dashboard(community)
+  - if @index || latest_vulnerability_assesment(community)
+    = render 'indices/mini_index', index: @index || latest_vulnerability_assesment(community)
   - else
     .not-available
-      No published AWRVI dashboards available.
+      No published Vulnerability Assesments available.

--- a/app/views/communities/_no_published_available.html.haml
+++ b/app/views/communities/_no_published_available.html.haml
@@ -1,6 +1,6 @@
 .jumbotron
   .text-center
-    %h2 No published AWRVI dashboards available.
-    %p Find out how to get started creating AWRVI Dashboards
+    %h2 No published Vulnerability Assesments available.
+    %p Find out how to get started creating Vulnerability Assesments
     = link_to new_community_index_path(community), class: 'btn btn-success btn-lg' do
-      Start new AWRVI Dashboard
+      Start new Vulnerability Assesment

--- a/app/views/communities/_past_vulnerability_assessments.html.haml
+++ b/app/views/communities/_past_vulnerability_assessments.html.haml
@@ -1,4 +1,4 @@
-%h4.text-center{style: 'margin-top: 20px;' } Additional AWRVI dashboards
+%h4.text-center{style: 'margin-top: 20px;' } Additional Vulnerability Assesments
 .list-group
   - community.indices.accessible_by(current_ability, :read).recent.each do |index|
     = active_link_to index, class: 'list-group-item' do

--- a/app/views/manage/users/show.html.haml
+++ b/app/views/manage/users/show.html.haml
@@ -11,7 +11,7 @@
       %th.col-sm-2 AWRVI Index
       %th.col-sm-2 Last Updated
       %th.col-sm-3 Progress
-      %th.col-sm-2 View AWRVI Dashboard
+      %th.col-sm-2 View Vulnerability Assesment
   %tbody
     - @indices.each do |index|
       %tr

--- a/app/views/pages/_recent_indicies.html.haml
+++ b/app/views/pages/_recent_indicies.html.haml
@@ -1,4 +1,4 @@
-%h2 Recent AWRVI dashboards
+%h2 Recent Vulnerability Assesments
 .community-list.row-fluid.text-center{ style: 'margin-top: 20px;' }
   - recent_indicies.limit(6).each do |index|
     .community-item.col-xs-12.col-md-4

--- a/app/views/pages/_search.html.haml
+++ b/app/views/pages/_search.html.haml
@@ -1,4 +1,4 @@
-%h2 Search communities for published AWRVI dashboards or to start a new dashboard
+%h2 Search communities for published Vulnerability Assesments or to start a new Vulnerability Assesment
 = form_tag :communities, method: :get, class: '' do
   .row
     .col-xs-9.col-sm-10

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -16,7 +16,7 @@
       .col-sm-3
         = link_to '#recent', class: 'btn btn-default btn-lg btn-block', data: { behavior: 'scroll', turbolinks: false } do
           %i.fa.fa-clock-o
-          Recent AWRVI Dashboards
+          Recent Vulnerability Assesments
   #description.description
     .container
       %h2 About AWRVI


### PR DESCRIPTION
@gina-alaska/awrvi  Please review.

Looking through the docs we've been given, I see the term 'Vulnerabilty Assessment' being used to describe what we've been calling the dashboard, which I think is a better and more accurate term.  This PR changes all references to `AWRVI Dashboard` to `Vulnerability Assessment`
