### PR TITLE
Fix multiple AWRVI versions

### DIFF
--- a/app/controllers/indices_controller.rb
+++ b/app/controllers/indices_controller.rb
@@ -20,7 +20,7 @@ class IndicesController < ApplicationController
 
   # GET /indices/new
   def new
-    category = Category.root
+    category = Category.active_root.first
     @index = @community.indices.build awrvi_version: category
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,8 @@ class Category < ApplicationRecord
   has_many :choices, -> { order(index: :asc) }, dependent: :destroy
   has_many :indices
 
+  scope :active_root, -> { where(name: "AWRVI 2.0") }
+
   def no_destroy
     false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,17 +5,17 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-def create_category(seed_data)
-  c = Category.where(name: seed_data['name']).first_or_create(category_params(seed_data))
-  c.children << create_sub_categories(seed_data) if seed_data.has_key?('categories')
+def create_category(seed_data, parent = nil)
+  c = Category.where(name: seed_data['name'], parent_id: parent.try(:id)).first_or_create(category_params(seed_data))
+  c.children << create_sub_categories(seed_data, c) if seed_data.has_key?('categories')
   c.choices = create_choices(seed_data, c) if seed_data.has_key?('choices')
   c
 end
 
-def create_sub_categories(seed_data)
+def create_sub_categories(seed_data, parent)
   results = seed_data['categories'].each_with_index.map do |sub_c, position|
     sub_c['position'] ||= position
-    create_category(sub_c)
+    create_category(sub_c, parent)
   end
   results
 end

--- a/db/seeds/categories/awrvi-2.0.yaml
+++ b/db/seeds/categories/awrvi-2.0.yaml
@@ -4,9 +4,11 @@ short_name: AWRVI 2.0
 categories:
 - name: PHYSICAL SUB-INDEX
   short_name: Physical
+  position: 0
   categories:
   - name: Physical - natural supply
     short_name: Natural supply
+    position: 0
     categories:
     - name: Average annual precip. (mm)
       choices:
@@ -94,6 +96,7 @@ categories:
         description: "< 1"
   - name: Physical - municipal supply
     short_name: Municipal supply
+    position: 1
     categories:
     - name: Yield (L)
       choices:
@@ -157,6 +160,7 @@ categories:
         description: "> +10"
   - name: Physical - water quality
     short_name: Water quality
+    position: 2
     categories:
     - name: "Density of upstream development sites"
       choices:
@@ -182,6 +186,7 @@ categories:
         description: "Annual Monitoring"
   - name: Physical - Permafrost Status
     short_name: Permafrost Status
+    position: 3
     categories:
     - name: PF distribution
       choices:
@@ -197,6 +202,7 @@ categories:
         description: ">75% no permafrost"
   - name: Physical - subsistence habitat
     short_name: Subsistence habitat
+    position: 4
     categories:
     - name: Anadromous Stream kilometers (%)
       choices:
@@ -224,9 +230,11 @@ categories:
         description: "80-100%"
 - name: SOCIAL SUB-INDEX
   short_name: Social
+  position: 1
   categories:
   - name: Social - knowledge capacity
     short_name: Knowledge capacity
+    position: 0
     categories:
     - name: Traditional (per 1000)
       choices:
@@ -266,6 +274,7 @@ categories:
         description: "≥ 500"
   - name: Social - Collective Community Capacity
     short_name: Collective Community Capacity
+    position: 1
     categories:
     - name: Per capita income ($)
       choices:
@@ -297,6 +306,7 @@ categories:
         description: "Plan Implemented"
   - name: Social - institutional capacity
     short_name: Institutional capacity
+    position: 2
     categories:
     - name: "% area in protected status"
       choices:
@@ -312,6 +322,7 @@ categories:
         description: "> 50%"
   - name: Social - cultural capacity
     short_name: Cultural capacity
+    position: 3
     categories:
     - name: Subsistence
       choices:
@@ -327,6 +338,7 @@ categories:
         description: "≥ 250"
   - name: Social - Mobility
     short_name: Mobility
+    position: 4
     categories:
     - name: Mode Diversity (fixed-wing air, road, boat, ATV/trail)
       choices:

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -6,7 +6,7 @@ namespace :dev do
   task prime: :environment do
     next if Index.any?
     Rake::Task["db:seed"].invoke
-    awrvi_version = Category.roots.first
+    awrvi_version = Category.active_root.first
     user = User.first_or_create(name: 'system', email: 'system@system.com',
                                 encrypted_password: 'system', password: 'system88',
                                 sign_in_count: 1)


### PR DESCRIPTION
This fixes problems with multiple AWRVI versions being present.
- Fix seeds to allow categories with same name/different parent
- Add active root scope on Category
- Replace instances of `Category.root` with `Category.active_root`

The active root scope is an ugly hack until we decide how we want to handle setting the current AWRVI version. 

@gina-alaska/awrvi  Please review
